### PR TITLE
Add missing dependencies to dchic.yml

### DIFF
--- a/packages/dchic.yml
+++ b/packages/dchic.yml
@@ -1,16 +1,18 @@
 name: dchic
 channels:
-  - bioconda
   - conda-forge
-  - r
-  - defaults
+  - bioconda
+
 dependencies:
   - bedtools
   - cooler
   - bioconductor-limma
   - bioconductor-ihw
+  - fithic>=2.0.8
+  - igv-reports
   - matplotlib
   - numpy
+  - pandoc
   - scikit-learn
   - scipy
   - sortedcontainers
@@ -26,10 +28,7 @@ dependencies:
   - r-robust
   - r-r.utils
   - r-data.table
-  - python=3.7
+  - python>=3.7
   - pysam
-  - pip
   - requests
-  - pip:
-    - igv-reports
 


### PR DESCRIPTION
Hi,

Congrats for the recent publication on [NatCom](https://www.nature.com/articles/s41467-022-34626-6)!

I am sharing 3 PRs (this is the first one) with some small changes I had to apply to make dcHiC run smoothly on my machines (all running various flavors of Linux).

This PR updates `dchic.yml` as follows:
- Add  `fithic>=2.0.8`: required to run `dchicf.r ... fithic` (thanks to https://github.com/bioconda/bioconda-recipes/commit/461e6de3cb72a29dfd1050c85fe4b9d4d6cdf058, this does no longer cause issues with env using `python>=3.7`)
- Add `pandoc`: required to run `dchic.r ... viz`
- Install `igv-reports` directly with `conda` instead of using `pip`
- Relax python version requirement
- Remove unused channels

