### PR TITLE
Update piped calls to 'sort -k 1,1' in dchicf.r to 'sort -k1,1V,' which prevents bedtools chromosome-order (and subsequent) errors when running 'dchicf.r --pcatype select'

### DIFF
--- a/dchicf.r
+++ b/dchicf.r
@@ -692,7 +692,7 @@ pcselect <- function(data, genome, pc, diroverwrite, folder=NA) {
    		system(paste0("gunzip -c ",folder,"/",genome,".fa.gz > ",folder,"/",genome,".fa"), wait=T)
 	}
 	if (!file.exists(paste0(folder,"/",genome,".tss.bed"))) {
-   		cmd <- paste0("gunzip -c ",folder,"/",genome,".refGene.gtf.gz |awk -v OFS='\\t' '{if($3==\"transcript\"){if($7==\"+\"){print $1,$4,$4+1}else{print $1,$5-1,$5}}}' |grep -v \"alt\" |grep -v \"random\" |sort |uniq |sort -k 1,1 -k2,2n > ",folder,"/",genome,".tss.bed")
+   		cmd <- paste0("gunzip -c ",folder,"/",genome,".refGene.gtf.gz |awk -v OFS='\\t' '{if($3==\"transcript\"){if($7==\"+\"){print $1,$4,$4+1}else{print $1,$5-1,$5}}}' |grep -v \"alt\" |grep -v \"random\" |sort |uniq |sort -k1,1V -k2,2n > ",folder,"/",genome,".tss.bed")
    		cat ("Running ",cmd,"\n")
    		system(cmd, wait=T)
 	}
@@ -702,7 +702,7 @@ pcselect <- function(data, genome, pc, diroverwrite, folder=NA) {
    		system(cmd, wait=T)
 	}
 	if (!file.exists(paste0(folder,"/",genome,".GCpt.bedGraph"))) {
-  		cmd <- paste0(.findExecutable("bedtools")," nuc -fi ",folder,"/",genome,".fa -bed ",folder,"/",genome,".binned.bed |grep -v \"#\" |awk -v OFS='\\t' '{print $1,$2,$3,$5}' |grep -v \"alt\" |grep -v \"random\" |sort -k 1,1 -k2,2n > ",folder,"/",genome,".GCpt.bedGraph")
+  		cmd <- paste0(.findExecutable("bedtools")," nuc -fi ",folder,"/",genome,".fa -bed ",folder,"/",genome,".binned.bed |grep -v \"#\" |awk -v OFS='\\t' '{print $1,$2,$3,$5}' |grep -v \"alt\" |grep -v \"random\" |sort -k1,1V -k2,2n > ",folder,"/",genome,".GCpt.bedGraph")
   		cat ("Running ",cmd,"\n")
    		system(cmd, wait=T)
 	}
@@ -2405,7 +2405,7 @@ geneEnrichment <- function(data, diffdir, genome, exclA=T, region="anchor", pcgr
    			system(paste0("gunzip -c ",folder_genome,"/",genome,".fa.gz > ",folder_genome,"/",genome,".fa"), wait=T)
 		}
 		if (!file.exists(paste0(folder_genome,"/",genome,".tss.bed"))) {
-   			cmd <- paste0("gunzip -c ",folder_genome,"/",genome,".refGene.gtf.gz |awk -v OFS='\\t' '{if($3==\"transcript\"){if($7==\"+\"){print $1,$4,$4+1}else{print $1,$5-1,$5}}}' |grep -v \"alt\" |grep -v \"random\" |sort |uniq |sort -k 1,1 -k2,2n > ",folder_genome,"/",genome,".tss.bed")
+   			cmd <- paste0("gunzip -c ",folder_genome,"/",genome,".refGene.gtf.gz |awk -v OFS='\\t' '{if($3==\"transcript\"){if($7==\"+\"){print $1,$4,$4+1}else{print $1,$5-1,$5}}}' |grep -v \"alt\" |grep -v \"random\" |sort |uniq |sort -k1,1V -k2,2n > ",folder_genome,"/",genome,".tss.bed")
    			cat ("Running ",cmd,"\n")
    			system(cmd, wait=T)
 		}
@@ -2415,7 +2415,7 @@ geneEnrichment <- function(data, diffdir, genome, exclA=T, region="anchor", pcgr
    			system(cmd, wait=T)
 		}
 		if (!file.exists(paste0(folder_genome,"/",genome,".GCpt.bedGraph"))) {
-  			cmd <- paste0(.findExecutable("bedtools")," nuc -fi ",folder_genome,"/",genome,".fa -bed ",folder_genome,"/",genome,".binned.bed |grep -v \"#\" |awk -v OFS='\\t' '{print $1,$2,$3,$5}' |grep -v \"alt\" |grep -v \"random\" |sort -k 1,1 -k2,2n > ",folder_genome,"/",genome,".GCpt.bedGraph")
+  			cmd <- paste0(.findExecutable("bedtools")," nuc -fi ",folder_genome,"/",genome,".fa -bed ",folder_genome,"/",genome,".binned.bed |grep -v \"#\" |awk -v OFS='\\t' '{print $1,$2,$3,$5}' |grep -v \"alt\" |grep -v \"random\" |sort -k1,1V -k2,2n > ",folder_genome,"/",genome,".GCpt.bedGraph")
   			cat ("Running ",cmd,"\n")
    			system(cmd, wait=T)
 		}
@@ -2968,3 +2968,4 @@ if (pcatype == "enrich") {
 if (sthread > 1) {
 	parallel::stopCluster(cl_sthread)
 }
+


### PR DESCRIPTION

Hi @ay-lab,

Thank you so much for making and maintaining this tool. I'm using the most recent dcHiC version 2. I encountered a bug in which, when running `dchicf.r --pcatype select`, the resulting GCpt.bedGraph file was sorted in "chromosome string"/lexicographic order rather than "chromosome numerical"/natural order:

<details>
<summary><i>Observed and expected outfile chromosome orders</i></summary>

<i>Observed outfile chromosome order (chromosome string/lexicographic order)</i>
```txt
cat Homo_sapiens.GRCh38.110.GCpt.bedGraph | cut -f1 | uniq
1
10
11
12
13
14
15
16
17
18
19
2
20
21
22
3
4
5
6
7
8
9
X
```

<i>Expected outfile chromosome order  (chromosome numerical/natural order)</i>
```txt
cat Homo_sapiens.GRCh38.110.GCpt.bedGraph | cut -f1 | uniq
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
X
```
</details>
<br />

This resulted in the following errors:
<details>
<summary><i>Error text, etc.</i></summary>

```txt
❯ if ${submit_job}; then
>     Rscript "${d_dcHiC}/dchicf.r" \
>         --file "${f_infile}" \
>         --pcatype select \
>         --dirovwt T \
>         --genome="${n_genome}" \
>         --gfolder "${d_base}/${d_proj}/${n_genome}_${res}_goldenpathData"
> fi
Running  /home/kalavatt/miniconda3/envs/dcHiC_env/bin/bedtools makewindows -g /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.chrom.sizes -w 40000 > /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.binned.bed
Running  /home/kalavatt/miniconda3/envs/dcHiC_env/bin/bedtools nuc -fi /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.fa -bed /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.binned.bed |grep -v "#" |awk -v OFS='\t' '{print $1,$2,$3,$5}' |grep -v "alt" |grep -v "random" |sort -k 1,1 -k2,2n > /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.GCpt.bedGraph
Running  /home/kalavatt/miniconda3/envs/dcHiC_env/bin/bedtools map -a /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.GCpt.bedGraph -b /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.tss.bed -c 1 -o count -null 0 > /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.GCpt.tss.bedGraph
ERROR: chromomsome sort ordering for file /fh/fast/tsukiyama_t/grp/tsukiyamalab/kalavatt/2023_rDNA/results/2023-1018_work_Hi-C_align-process/Homo_sapiens.GRCh38.110_40000_goldenpathData/Homo_sapiens.GRCh38.110.tss.bed is inconsistent with other files. Record was:
10	20930	20931	ENSG00000260370	0	-
Running  intra   1  in  D14_no2_40000  sample
Running  intra   1  in  D14_no7_40000  sample
Running  intra   2  in  D14_no2_40000  sample
Running  intra   2  in  D14_no7_40000  sample
Running  intra   3  in  D14_no2_40000  sample
Running  intra   3  in  D14_no7_40000  sample
Running  intra   4  in  D14_no2_40000  sample
Running  intra   4  in  D14_no7_40000  sample
Running  intra   5  in  D14_no2_40000  sample
Running  intra   5  in  D14_no7_40000  sample
Running  intra   6  in  D14_no2_40000  sample
Running  intra   6  in  D14_no7_40000  sample
Running  intra   7  in  D14_no2_40000  sample
Running  intra   7  in  D14_no7_40000  sample
Running  intra   8  in  D14_no2_40000  sample
Running  intra   8  in  D14_no7_40000  sample
Running  intra   9  in  D14_no2_40000  sample
Running  intra   9  in  D14_no7_40000  sample
Error in hclust(as.dist(round(1 - cor(pc.mat), 4))) :
  NA/NaN/Inf in foreign function call (arg 10)
Calls: pcselect -> pcselectioncore -> hclust
Execution halted
```
</details>
<br />

How I am calling dcHiC thus far:
<details>
<summary><i>Calls to dcHiC</i></summary>

```bash
#  Step 1
Rscript "${dir_dcHiC}/dchicf.r" \
    --file "${infile}" \
    --pcatype cis \
    --dirovwt T \
    --cthread $(( threads )) \
    --pthread $(( threads ))

#  Step 2
Rscript "${d_dcHiC}/dchicf.r" \
    --file "${infile}" \
    --pcatype select \
    --dirovwt T \
    --genome="${name_genome}" \
    --gfolder "${dir_base}/${dir_proj}/${name_genome}_${res}_goldenpathData"
```
</details>
<br />

Solution:
The issue arises due to the default sorting behavior of the `sort` command, which doesn't handle numeric sorting of chromosomes in the natural order. One solution is to modify the relevant sort command within the dcHiC script to use the `--version-sort` (`-V`) option. This option enables natural sorting of numbers, ensuring chromosomes are sorted in the correct numerical order rather than lexicographically. This change corrects the chromosome order in the output files and resolve the discrepancies encountered during processing.

I believe `-V` is available in both GNU and BSD versions of `sort`. I've only tested this with GNU versions.